### PR TITLE
Update and bugfix parseseconds and parseminutes

### DIFF
--- a/main.py
+++ b/main.py
@@ -100,9 +100,7 @@ class SpotifyOverlay():
     def hide(self):
         self.win.withdraw()
     def parseseconds(self, millis):
-        seconds = millis / (1000 ^ 60) %60
-        return int(seconds)
+        return (millis // 1000) % 60
     def parseminutes(self, millis):
-        minutes = millis / (1000 * 60) % 60
-        return int(minutes)
+        return (millis // (1000 * 60)) % 60
 SpotifyOverlay()


### PR DESCRIPTION
Parseseconds was bugged, 1000 ^ 60 = 980 (^ is bitwise XOR in python) so parseseconds was really counting every 980ms as a second.
Rewrote both functions to remove intermediate variables and to use integer division (//) to take care of removing decimal places rather than casting to int.